### PR TITLE
Initial Rails 4.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= vestal_versions for Rails 3
+= vestal_versions for Rails 4
 
 Finally, DRY ActiveRecord versioning!
 
@@ -10,7 +10,7 @@ And that's just what <tt>vestal_versions</tt> does. Not only can a model be reve
 
 == Compatibility
 
-Tested with Active Record 3.0.3 with Ruby 1.8.7 and 1.9.2.
+Tested with Active Record 4.2 with Ruby 2.3.1.
 
 == Installation
 

--- a/lib/vestal_versions/version.rb
+++ b/lib/vestal_versions/version.rb
@@ -72,7 +72,7 @@ module VestalVersions
 
         model
       else
-        latest_version = self.class.find(:first, :conditions => {:versioned_id => versioned_id, :versioned_type => versioned_type, :tag => 'deleted'})
+        latest_version = self.class.where(:versioned_id => versioned_id, :versioned_type => versioned_type, :tag => 'deleted').first
         latest_version.nil? ? nil : latest_version.restore
       end
     end

--- a/lib/vestal_versions/versions.rb
+++ b/lib/vestal_versions/versions.rb
@@ -13,16 +13,15 @@ module VestalVersions
       return [] if from_number.nil? || to_number.nil?
 
       condition = (from_number == to_number) ? to_number : Range.new(*[from_number, to_number].sort)
-      all(
-        :conditions => {:number => condition},
-        :order => "#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}"
-      )
+      where(:number => condition)
+        .order("#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}")
+        .to_a
     end
 
     # Returns all version records created before the version associated with the given value.
     def before(value)
       return [] if (number = number_at(value)).nil?
-      all(:conditions => "#{table_name}.#{connection.quote_column_name('number')} < #{number}")
+      where("#{table_name}.#{connection.quote_column_name('number')} < #{number}").to_a
     end
 
     # Returns all version records created after the version associated with the given value.
@@ -30,7 +29,7 @@ module VestalVersions
     # This is useful for dissociating records during use of the +reset_to!+ method.
     def after(value)
       return [] if (number = number_at(value)).nil?
-      all(:conditions => "#{table_name}.#{connection.quote_column_name('number')} > #{number}")
+      where("#{table_name}.#{connection.quote_column_name('number')} > #{number}").to_a
     end
 
     # Returns a single version associated with the given value. The following formats are valid:
@@ -49,7 +48,7 @@ module VestalVersions
     #   untouched.
     def at(value)
       case value
-        when Date, Time then last(:conditions => ["#{table_name}.created_at <= ?", value.to_time])
+        when Date, Time then where("#{table_name}.created_at <= ?", value.to_time).last
         when Numeric then find_by_number(value.floor)
         when String then find_by_tag(value)
         when Symbol then respond_to?(value) ? send(value) : nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@ Bundler.require
 require 'rspec/core'
 
 RSpec.configure do |c|
+  # Enable deprecated `should` expectation syntax alongside `expect`
+  c.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
+
   c.before(:suite) do
     CreateSchema.suppress_messages{ CreateSchema.migrate(:up) }
   end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -8,7 +8,7 @@ class CreateSchema < ActiveRecord::Migration
     create_table :users, :force => true do |t|
       t.string :first_name
       t.string :last_name
-      t.timestamps
+      t.timestamps null: false
     end
 
     create_table :versions, :force => true do |t|
@@ -19,7 +19,7 @@ class CreateSchema < ActiveRecord::Migration
       t.integer :number
       t.integer :reverted_from
       t.string :tag
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/vestal_versions/conditions_spec.rb
+++ b/spec/vestal_versions/conditions_spec.rb
@@ -46,7 +46,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count + 1 }
+        it 'should have an additional version' do
+          subject.versions.count.should == count + 1
+        end
       end
 
       context 'that fail' do
@@ -55,7 +57,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count }
+        it 'should have the same number of versions' do
+          subject.versions.count.should == count
+        end
       end
     end
 
@@ -66,7 +70,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count }
+        it 'should have the same number of versions' do
+          subject.versions.count.should == count
+        end
       end
 
       context 'that fail' do
@@ -75,7 +81,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count + 1 }
+        it 'should have an additional version' do
+          subject.versions.count.should == count + 1
+        end
       end
     end
 
@@ -86,7 +94,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count }
+        it 'should have the same number of versions' do
+          subject.versions.count.should == count
+        end
       end
 
       context 'that fail' do
@@ -95,7 +105,9 @@ describe VestalVersions::Conditions do
           subject.update_attribute(:last_name, 'Jobs')
         end
 
-        its('versions.count'){ should == count }
+        it 'should have the same number of versions' do
+          subject.versions.count.should == count
+        end
       end
     end
 

--- a/spec/vestal_versions/creation_spec.rb
+++ b/spec/vestal_versions/creation_spec.rb
@@ -6,14 +6,18 @@ describe VestalVersions::Creation do
 
   context 'the number of versions' do
 
-    its('versions.count'){ should == 0 }
+    it 'should have zero versions' do
+      subject.versions.count.should == 0
+    end
 
     context 'with :initial_version option' do
       before do
         User.prepare_versioned_options(:initial_version => true)
       end
 
-      its('versions.count'){ should == 1 }
+      it 'should have one version' do
+        subject.versions.count.should == 1
+      end
     end
 
     it 'does not increase when no changes are made in an update' do


### PR DESCRIPTION
### Objective

Update the project to remove deprecation warnings when using in a Rails 4.2 & Ruby 2.3 environment. Also get the specs to a passing state.
### Changes
- Change Rails 3 style finders to Rails 4 style: `find(:conditions...)` to `where(conditions)`
- Change deprecated `relation.all` usage to `relation.to_a` in order to retrieve array of records
- Replace uses of `its` example declarations to `it` blocks (`its` is no longer included with `rspec`)
- Fix `should` rspec deprecation warning by explicitly requiring it in `spec_helper`
- Fix timestamp null value deprecation warnings by explicitly setting `null: false`
- Fix Gemfile `rubygem` deprecation warning by explicitly using `https`
- Update Readme to hint at the current state of the project
