### PR TITLE
Make the changes necessary to use this gem in a Rails 5.2 context

### DIFF
--- a/lib/generators/vestal_versions/migration/templates/migration.rb
+++ b/lib/generators/vestal_versions/migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateVestalVersions < ActiveRecord::Migration[5.2]
+class CreateVestalVersions < ActiveRecord::Migration[5.1]
   def self.up
     create_table :versions do |t|
       t.belongs_to :versioned, :polymorphic => true

--- a/lib/generators/vestal_versions/migration/templates/migration.rb
+++ b/lib/generators/vestal_versions/migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateVestalVersions < ActiveRecord::Migration
+class CreateVestalVersions < ActiveRecord::Migration[5.2]
   def self.up
     create_table :versions do |t|
       t.belongs_to :versioned, :polymorphic => true

--- a/lib/vestal_versions/changes.rb
+++ b/lib/vestal_versions/changes.rb
@@ -25,7 +25,7 @@ module VestalVersions
       backward ? chain.pop : chain.shift unless from_number == 1 || to_number == 1
 
       chain.inject({}) do |changes, version|
-        changes.append_changes!(backward ? version.changes.reverse_changes : version.changes)
+        changes.append_changes!(backward ? version.saved_changes.reverse_changes : version.saved_changes)
       end
     end
 
@@ -47,7 +47,7 @@ module VestalVersions
     # creation. Incremental changes are reset when the record is saved because they represent
     # a subset of the dirty attribute changes, which are reset upon save.
     def incremental_version_changes
-      changes.slice(*versioned_columns)
+      saved_changes.slice(*versioned_columns)
     end
 
     # Simply resets the cumulative changes after version creation.

--- a/lib/vestal_versions/control.rb
+++ b/lib/vestal_versions/control.rb
@@ -95,12 +95,12 @@ module VestalVersions
     #
     #   user = User.find_by_first_name("Steve")
     #   user.version # => 2
-    #   user.versions.last.changes
+    #   user.versions.last.saved_changes
     #   # => {"first_name" => ["Stephen", "Steve"]}
     #   user.append_version do
     #     user.last_name = "Jobs"
     #   end
-    #   user.versions.last.changes
+    #   user.versions.last.saved_changes
     #   # => {"first_name" => ["Stephen", "Steve"], "last_name" => ["Richert", "Jobs"]}
     #   user.version # => 2
     #

--- a/lib/vestal_versions/creation.rb
+++ b/lib/vestal_versions/creation.rb
@@ -63,7 +63,7 @@ module VestalVersions
       def update_version
         return create_version unless v = versions.last
         v.modifications_will_change!
-        v.update_attribute(:modifications, v.changes.append_changes(version_changes))
+        v.update_attribute(:modifications, v.saved_changes.append_changes(version_changes))
         reset_version_changes
         reset_version
       end

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -19,15 +19,18 @@ module VestalVersions
       super.merge(:user => updated_by)
     end
 
-    # Instance methods added to VestalVersions::Version to accomodate incoming user information.
+    # Instance methods added to VestalVersions::Version to accommodate incoming user information.
     module VersionMethods
       extend ActiveSupport::Concern
 
       included do
         belongs_to :user, :polymorphic => true
 
-        alias_method_chain :user, :name
-        alias_method_chain :user=, :name
+        alias_method :user_without_name, :user
+        alias_method :user, :user_with_name
+
+        alias_method :user_without_name=, :user=
+        alias_method :user=, :user_with_name=
       end
 
       # Overrides the +user+ method created by the polymorphic +belongs_to+ user association. If

--- a/lib/vestal_versions/version.rb
+++ b/lib/vestal_versions/version.rb
@@ -10,12 +10,8 @@ module VestalVersions
     # Associate polymorphically with the parent record.
     belongs_to :versioned, :polymorphic => true
 
-    # ActiveRecord::Base#changes is an existing method, so before serializing the +changes+ column,
-    # the existing +changes+ method is undefined. The overridden +changes+ method pertained to
-    # dirty attributes, but will not affect the partial updates functionality as that's based on
-    # an underlying +changed_attributes+ method, not +changes+ itself.
-    undef_method :changes
-    def changes
+    # This used to be an override of the #changes method, but that was deprecated as of AR 5.2.
+    def saved_changes
       self[:modifications]
     end
     serialize :modifications, Hash

--- a/lib/vestal_versions/version_num.rb
+++ b/lib/vestal_versions/version_num.rb
@@ -1,3 +1,3 @@
 module VestalVersions
-  VERSION = '1.2.2'
+  VERSION = '1.3'
 end

--- a/lib/vestal_versions/versions.rb
+++ b/lib/vestal_versions/versions.rb
@@ -14,7 +14,7 @@ module VestalVersions
 
       condition = (from_number == to_number) ? to_number : Range.new(*[from_number, to_number].sort)
       where(:number => condition)
-        .order("#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}")
+        .order(Arel.sql("#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}"))
         .to_a
     end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -3,7 +3,7 @@ ActiveRecord::Base.establish_connection(
   :database => File.expand_path('../../test.db', __FILE__)
 )
 
-class CreateSchema < ActiveRecord::Migration[5.2]
+class CreateSchema < ActiveRecord::Migration[5.1]
   def self.up
     create_table :users, :force => true do |t|
       t.string :first_name

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -3,7 +3,7 @@ ActiveRecord::Base.establish_connection(
   :database => File.expand_path('../../test.db', __FILE__)
 )
 
-class CreateSchema < ActiveRecord::Migration
+class CreateSchema < ActiveRecord::Migration[5.2]
   def self.up
     create_table :users, :force => true do |t|
       t.string :first_name

--- a/spec/vestal_versions/changes_spec.rb
+++ b/spec/vestal_versions/changes_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe VestalVersions::Changes do
   context "a version's changes" do
     let(:user){ User.create(:name => 'Steve Richert') }
-    subject{ user.versions.last.changes }
+    subject{ user.versions.last.saved_changes }
 
     before do
       user.update_attribute(:last_name, 'Jobs')
@@ -31,7 +31,7 @@ describe VestalVersions::Changes do
       user.first_name = 'Stephen'
       model_changes = user.changes
       user.save
-      changes = user.versions.last.changes
+      changes = user.versions.last.saved_changes
 
       model_changes.should == changes
     end

--- a/spec/vestal_versions/control_spec.rb
+++ b/spec/vestal_versions/control_spec.rb
@@ -95,7 +95,7 @@ describe VestalVersions::Control do
 
         user.append_version{ user.update_attribute(:last_name, 'Jobs') }
 
-        other_last_version = user.versions(true).last
+        other_last_version = user.versions.last
         other_last_version.id.should == original_id
         other_last_version.attributes.should_not == original_attrs
       end
@@ -110,7 +110,7 @@ describe VestalVersions::Control do
           user.update_attribute(:first_name, 'Steve')
         end
 
-        other_last_version = user.versions(true).last
+        other_last_version = user.versions.last
         other_last_version.id.should == original_id
         other_last_version.attributes.should_not == original_attrs
       end

--- a/spec/vestal_versions/creation_spec.rb
+++ b/spec/vestal_versions/creation_spec.rb
@@ -52,7 +52,7 @@ describe VestalVersions::Creation do
 
     it 'does not contain Rails timestamps' do
       %w(created_at created_on updated_at updated_on).each do |timestamp|
-        subject.versions.last.changes.keys.should_not include(timestamp)
+        subject.versions.last.saved_changes.keys.should_not include(timestamp)
       end
     end
 
@@ -60,14 +60,14 @@ describe VestalVersions::Creation do
       User.prepare_versioned_options(:only => [:first_name])
       subject.update_attribute(:name, 'Steven Tyler')
 
-      subject.versions.last.changes.keys.should == ['first_name']
+      subject.versions.last.saved_changes.keys.should == ['first_name']
     end
 
     it 'allows specific columns to be excluded via :except' do
       User.prepare_versioned_options(:except => [:first_name])
       subject.update_attribute(:name, 'Steven Tyler')
 
-      subject.versions.last.changes.keys.should_not include('first_name')
+      subject.versions.last.saved_changes.keys.should_not include('first_name')
     end
 
     it "prefers :only to :except" do
@@ -75,7 +75,7 @@ describe VestalVersions::Creation do
         :except => [:first_name])
       subject.update_attribute(:name, 'Steven Tyler')
 
-      subject.versions.last.changes.keys.should == ['first_name']
+      subject.versions.last.saved_changes.keys.should == ['first_name']
     end
   end
 

--- a/spec/vestal_versions/reset_spec.rb
+++ b/spec/vestal_versions/reset_spec.rb
@@ -29,7 +29,7 @@ describe VestalVersions::Reset do
   it 'dissociates all versions after the target' do
     versions.reverse.each do |version|
       subject.reset_to!(version)
-      subject.versions(true).after(version).count.should == 0
+      subject.versions.after(version).count.should == 0
     end
   end
 

--- a/spec/vestal_versions/versions_spec.rb
+++ b/spec/vestal_versions/versions_spec.rb
@@ -125,15 +125,15 @@ describe VestalVersions::Versions do
 
   it 'provides a version number for any given numeric version value' do
     times.keys.each do |number|
-      subject.versions.number_at(number).should be_a(Fixnum)
-      subject.versions.number_at(number + 0.5).should be_a(Fixnum)
+      subject.versions.number_at(number).should be_a(Integer)
+      subject.versions.number_at(number + 0.5).should be_a(Integer)
       subject.versions.number_at(number).should == subject.versions.number_at(number + 0.5)
     end
   end
 
   it 'provides a version number for a valid tag' do
     times.keys.map{|n| [n, n.to_s] }.each do |number, tag|
-      subject.versions.number_at(tag).should be_a(Fixnum)
+      subject.versions.number_at(tag).should be_a(Integer)
       subject.versions.number_at(tag).should == number
     end
   end
@@ -155,7 +155,7 @@ describe VestalVersions::Versions do
 
   it "provides a version number for any time after the model's creation" do
     times.each do |number, time|
-      subject.versions.number_at(time + 30.minutes).should be_a(Fixnum)
+      subject.versions.number_at(time + 30.minutes).should be_a(Integer)
       subject.versions.number_at(time + 30.minutes).should == number
     end
   end

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = 'vestal_versions'
   s.version     = VestalVersions::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Adam Cooper"]
-  s.email       = ['adam.cooper@gmail.com']
+  s.authors     = ["Trakstar"]
+  s.email       = ['dev@trakstar.com']
   s.homepage    = 'http://github.com/adamcooper/vestal_versions'
   s.summary     = "Keep a DRY history of your ActiveRecord models' changes"
   s.description = "Keep a DRY history of your ActiveRecord models' changes"

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files spec`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'activerecord', '>= 3.1.0', '<= 5.1.6'
-  s.add_dependency 'activesupport', '>= 3.1.0', '<= 5.1.6'
+  s.add_dependency 'activerecord', '>= 3.1.0', '<= 5.2'
+  s.add_dependency 'activesupport', '>= 3.1.0', '<= 5.2'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files spec`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_dependency 'activerecord', '>= 3.1.0'
-  s.add_dependency 'activesupport', '>= 3.1.0'
+  s.add_dependency 'activerecord', '>= 3.1.0', '<= 5.1.6'
+  s.add_dependency 'activesupport', '>= 3.1.0', '<= 5.1.6'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
# Objective

Supports https://www.pivotaltracker.com/story/show/161830129, but doesn't complete it. There will be another PR in the `trakstar` repository that will integrate the work in this PR.

The purpose of this PR is to get `vestal_versions` ready for Rails 5.

# Notes

The trickiest part of this upgrade was navigating the under-the-hood `activerecord` changes from `4.2.10` to `5.2.1`. Simply using `bundle update activerecord` and troubleshooting from there made it _extremely difficult_ to see why the latest gems were breaking `vestal_versions` specs. The best strategy I could come up with was to set strategic breakpoints in both my `4.2.10` and `5.2.1` environments and compare the state of the in-memory data at various points of the spec suite. At one point, I even used the `#methods` method to compare the methods available on `activerecord` `4.2.10` models vs. `5.2.1` models 😂 that's how you really know debugging could be going better.

My initial brute force approach did help a little because I ultimately discovered a key overridden method that was not getting called in the `5.2.1` context -- a method called `changes` in the class `Version`. This method is simply there to override the default `activerecord` definition, but it wasn't getting called in my `5.2.1` bundle. That was when I realized the delta between the old and new versions of `activerecord` is fairly gnarly as far as `vestal_versions` is concerned.

I began reading more and more documentation and saw that there was some dramatic changes from `4.2.10` to `5.2.1`, so I had what ended up being a great idea -- incrementally update the gems. So I tried `5.0.x` and `5.1.x` and saw if I could get those upgrades to work. Using this strategy led me in the right direction because `5.1.x` happens to issue some very helpful deprecation warnings if you use a feature of `activerecord` that will soon be phased out.

I got this screenshot from someone's blog, but this is literally the same message I saw when I was in the `5.1.x` phase of the upgrade. This message was absolutely critical in learning how to update the code here to be Rails 5.2-ready:
<img width="693" alt="screen shot 2018-11-14 at 9 14 39 am" src="https://user-images.githubusercontent.com/17152324/48502377-42968f80-e7f4-11e8-98f5-ccf46b04be59.png">

Basically, I renamed _most_ calls to `changes` with a call to `saved_changes`.

There were a couple updates I made because of other deprecation warning I saw, but if I recall most of these were deprecation warnings for Rails 6.

# Testing

- [ ] `bundle install` and `bundle exec rspec spec` passes

The "real" test will be using this gem with the Trakstar `rails5` branch and seeing if versioning still works. Admittedly, I haven't done this yet but plan to very soon.